### PR TITLE
Fix issue where first row fails to play at start

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,6 +10,7 @@
 	let speed = 200;
 	let gameInterval;
 	let curRow = 0;
+	let lastRow = 0;
 	let shareMessage = 'Share';
 	let started = false;
 	let urlUpdatedRecently = false;
@@ -75,11 +76,12 @@
 		clearInterval(gameInterval);
 		gameInterval = setInterval(() => {
 			if(playing) {
-				let nextRow = (curRow + 1) % grid.length;
-				grid[curRow].isPlaying = false;
-				grid[nextRow].isPlaying = true;
-				curRow = nextRow;
+				grid[lastRow].isPlaying = false;
+				grid[curRow].isPlaying = true;
 				playRow(grid[curRow]);
+				let nextRow = (curRow + 1) % grid.length;
+				lastRow  = curRow;
+				curRow = nextRow;
 			}
 		},  60*1000 / bpm);
 


### PR DESCRIPTION
`playRow` was being invoked on `curRow` when `curRow` had already been changed to `nextRow`, and additionally, `nextRow` was being activated at the same time, so the note played and the row highlighted were correctly in sync, but row 0 never played during the first loop.

By keeping a record of the last row, we can turn its display off only when we start playing a new row, and then we can activate+play the current row, allowing 0 to actually be played on first loop. It also allows us to correctly deactivate the row at the end of the grid after wrapping.

https://github.com/irshadshalu/music-grid/pull/17 will need an update if this PR ends up being merged first.