### PR TITLE
Cleanup controls and use Icons instead of buttons

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -71,7 +71,6 @@ body {
 }
 
 input[type=range] {
-	width: 20em;
   margin: 6.3px 0;
   background-color: transparent;
   -webkit-appearance: none;

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
 	<meta property="og:title" content="Music Grid Piano. Create Beautiful Short Music Snippets" />
 	<meta property="og:url" content="https://music-grid.surge.sh" />
 	<meta property="og:image" content="/favicon.png" />
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
 	<!-- Global site tag (gtag.js) - Google Analytics -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-169258065-1"></script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,7 +3,7 @@
 	import Controls from './Controls.svelte';
 	import {initAudio, playRow} from './Music.svelte';
 
-	export let config = {
+	let config = {
 		playing: false,
 		speed: 200,
 		rows: 16

--- a/src/Controls.svelte
+++ b/src/Controls.svelte
@@ -1,0 +1,134 @@
+<script>
+	import { createEventDispatcher, onMount } from 'svelte';
+	import ClipboardJS from 'clipboard';
+
+	const dispatch = createEventDispatcher();
+
+	export let grid;
+	export let config;
+
+	let urlUpdatedRecently = false;
+	let settingsOpen = false;
+	let scrollY = 0;
+
+	const encodeGridToUrl = (grid, speed) => {
+		let res = ''
+		for (var i = grid.length - 1; i >= 0; i--) {
+			let temp = 0, k = 1;
+			for (var j = grid[i].length - 1; j >= 0; j--) {
+				temp = temp + k * grid[i][j];
+				k = k * 2;
+			}
+			res += (temp + '-');
+		}
+		history.replaceState({}, '', '#' + res + '&' + speed);
+	}
+
+	const updateUrl = (grid, speed) => {
+		if(!urlUpdatedRecently) {
+			encodeGridToUrl(grid, speed);
+			urlUpdatedRecently = true;
+			setTimeout(() => {urlUpdatedRecently = false}, 1000);
+		}
+	}
+
+	$: updateUrl(grid, config.speed);
+
+
+	let clipboard = new ClipboardJS('.share', {
+		text: function() {
+			encodeGridToUrl(grid, config.speed);
+			return window.location.href;
+		}
+	});
+
+
+	let header;
+	let headerOffset;
+	let primaryClass = "primary";
+
+	onMount(() => {
+		headerOffset = header.offsetTop;
+	});
+
+	const showSticky = (ignored) => {
+		if(headerOffset) {
+			if (window.pageYOffset > headerOffset) {
+				primaryClass = "primary sticky";
+			} else {
+				primaryClass = "primary";
+			}
+		}
+	}
+
+	$: showSticky(scrollY);
+
+</script>
+
+<style>
+
+	.fa {
+		transition: 0.06s ease-in;
+	}
+
+	.fa:hover {
+		transform: scale(1.1);
+	}
+
+	.fa:active {
+		transform: scale(0.8);
+	}
+
+	a {
+		margin-left: 1.3em;
+		margin-right: 1.3em;
+		padding: 10px;
+		color: white;
+	}
+
+	.primary, .settings {
+		padding: 10px;
+		background: black;
+	}
+
+	.sticky {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+	}
+</style>
+<svelte:window bind:scrollY={scrollY}/>
+
+<div class="container">
+	<div class="settings">
+		<label>
+			Rows :
+			<input bind:value={config.rows}
+			on:input={() => dispatch('rowchange')}
+			 type="range" min="8" max="100" class="slider">
+			 {config.rows}
+		</label>
+		<br/>
+		<label>
+			Speed :
+			<input bind:value={config.speed}
+			 type="range" min="60" max="500" class="slider">
+			 {config.speed}
+		</label>
+	</div>
+	<div class={primaryClass} bind:this={header}>
+		<a on:click={() => dispatch('playpause')}>
+			{#if config.playing}
+				<i class="fa fa-lg fa-inverse fa-pause"/>
+			{:else}
+				<i class="fa fa-lg fa-inverse fa-play"/>
+			{/if}
+		</a>
+		<a on:click={() => dispatch('stop')}><i class="fa fa-inverse fa-lg fa-stop"/></a>
+		<a class="share"><i class="fa fa-lg fa-share-alt"/></a>
+		<a on:click={() => dispatch('clear')}><i class="fa fa-lg fa-trash"/></a>
+	</div>
+	{#if settingsOpen}
+	{/if}
+</div>

--- a/src/Controls.svelte
+++ b/src/Controls.svelte
@@ -8,7 +8,6 @@
 	export let config;
 
 	let urlUpdatedRecently = false;
-	let settingsOpen = false;
 	let scrollY = 0;
 
 	const encodeGridToUrl = (grid, speed) => {
@@ -129,6 +128,4 @@
 		<a class="share"><i class="fa fa-lg fa-share-alt"/></a>
 		<a on:click={() => dispatch('clear')}><i class="fa fa-lg fa-trash"/></a>
 	</div>
-	{#if settingsOpen}
-	{/if}
 </div>

--- a/src/Music.svelte
+++ b/src/Music.svelte
@@ -23,9 +23,10 @@
 		console.log('audio is ready');
 	}
 
-	export const playRow = (row) => {
+	export const playRow = async (row) => {
 		if(!synth) {
 			console.error("Please initialize audio before playing a row");
+			await initAudio();
 			return;
 		}
 


### PR DESCRIPTION
Fixes #3  and #4 

Testable version available at http://musicgrid.irshadpi.me

1. Organized controls so that they are consistent
2. Used icons instead of buttons so that UI looks neater
3. Made primary control row sticky so that user can pause/stop while scrolling (This will help when implementing #10 )


When opening:
![Screen Shot 2020-06-20 at 12 14 49 AM](https://user-images.githubusercontent.com/8298478/85170682-62711d80-b28b-11ea-9a25-f148e4ea2e93.png)

After scrolling: 
![Screen Shot 2020-06-20 at 12 14 58 AM](https://user-images.githubusercontent.com/8298478/85170715-6bfa8580-b28b-11ea-9cc4-b49711fae654.png)
