### PR TITLE
Support multiple scales.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,14 +1,15 @@
 <script>
 	import Row from './Row.svelte';
 	import Controls from './Controls.svelte';
-	import {initAudio, playRow, startRecording, stopRecording} from './Music.svelte';
+	import {initAudio, playRow, startRecording, stopRecording, setScale} from './Music.svelte';
 	let config = {
 		playing: false,
 		speed: 200,
-		rows: 16
+		rows: 16,
+		scale_key: 'classic',
 	}
 
-	let columns = 12;
+	let columns = 14;
 	let grid = [];
 	let gameInterval;
 	let curRow = 0;
@@ -78,6 +79,9 @@
 		if(hash.split('&').length > 1) {
 			config.speed = parseInt(hash.split('&')[1], 10);
 		}
+		if(hash.split('&').length > 2) {
+			config.scale_key = hash.split('&')[2];
+		}
 	}
 
 	const changeSpeed = (bpm) => {
@@ -128,6 +132,7 @@
 <style>
 	table {
 		background: black;
+		transform: scale(0.9);
 	}
 
 	.container {
@@ -167,6 +172,7 @@
 		on:stop={stopPlaying}
 		on:clear={() => clearGrid(config.rows)}
 		on:rowchange={() => resizeGrid(config.rows)}
+		on:scalechange={() => setScale(config.scale_key)}
 		on:download={downloadAudio}
 	/>
 	{#if recording}

--- a/src/Controls.svelte
+++ b/src/Controls.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { createEventDispatcher, onMount } from 'svelte';
 	import ClipboardJS from 'clipboard';
+	import { scale_keys } from './Music.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -10,7 +11,7 @@
 	let urlUpdatedRecently = false;
 	let scrollY = 0;
 
-	const encodeGridToUrl = (grid, speed) => {
+	const encodeGridToUrl = (grid, speed, scale) => {
 		let res = ''
 		for (var i = grid.length - 1; i >= 0; i--) {
 			let temp = 0, k = 1;
@@ -20,23 +21,23 @@
 			}
 			res += (temp + '-');
 		}
-		history.replaceState({}, '', '#' + res + '&' + speed);
+		history.replaceState({}, '', '#' + res + '&' + speed + '&' + scale);
 	}
 
-	const updateUrl = (grid, speed) => {
+	const updateUrl = (grid, speed, scale) => {
 		if(!urlUpdatedRecently) {
-			encodeGridToUrl(grid, speed);
+			encodeGridToUrl(grid, speed, scale);
 			urlUpdatedRecently = true;
 			setTimeout(() => {urlUpdatedRecently = false}, 1000);
 		}
 	}
 
-	$: updateUrl(grid, config.speed);
+	$: updateUrl(grid, config.speed, config.scale_key);
 
 
 	let clipboard = new ClipboardJS('.share', {
 		text: function() {
-			encodeGridToUrl(grid, config.speed);
+			encodeGridToUrl(grid, config.speed, config.scale_key);
 			return window.location.href;
 		}
 	});
@@ -96,6 +97,13 @@
 		left: 0;
 		width: 100%;
 	}
+
+	select {
+		background: black;
+		color: white;
+		border: none;
+		outline: none;
+	}
 </style>
 <svelte:window bind:scrollY={scrollY}/>
 
@@ -114,6 +122,17 @@
 			<input bind:value={config.speed}
 			 type="range" min="60" max="500" class="slider">
 			 {config.speed}
+		</label>
+		<br/>
+		<label>
+			Scale :
+			<select bind:value={config.scale_key} on:change={() => dispatch('scalechange')}>
+				{#each scale_keys as scale}
+				<option value={scale}>
+					{scale}
+				</option>
+				{/each}
+			</select>
 		</label>
 	</div>
 	<div class={primaryClass} bind:this={header}>

--- a/src/Music.svelte
+++ b/src/Music.svelte
@@ -6,11 +6,43 @@
 	let recorder;
 	let destinationStream;
 
-	let notes = [
-		'B3', 'C#4', 'F#4', 'G#4',
-		'C#5', 'D#5', 'E5', 'G#5',
-		'B5', 'C#6', 'F#6', 'G#6'
-	];
+	let scales = {
+		classic: [
+		  // first two notes not in early compositions
+			'E3', 'G#3',
+			'B3', 'C#4', 'F#4', 'G#4',
+			'C#5', 'D#5', 'E5', 'G#5',
+			'B5', 'C#6', 'F#6', 'G#6'
+		],
+		pentatonic: [
+		  'G3', 'A3',
+			'C4', 'D4', 'E4', 'G4',
+			'A4', 'C5', 'D5', 'E5',
+			'G5', 'A5', 'C6', 'D6',
+		],
+		chromatic: [
+			'C5', 'C#5', 'D5', 'Eb5',
+			'E5', 'F5', 'F#5', 'G5',
+			'G#5','A5', 'Bb5', 'B5',
+			'C6', 'C#6',
+		],
+		major: [
+			'C4', 'D4', 'E4', 'F4',
+			'G4', 'A4', 'B4', 'C5',
+			'D5', 'E5', 'F5', 'G5',
+			'A5', 'B5',
+		],
+		harmonic_minor: [
+			'A4', 'B4', 'C5', 'D5',
+			'E5', 'F5', 'G#5', 'A5',
+			'B5', 'C6', 'D6', 'E6',
+			'F6', 'G#6',
+		],
+	};
+
+	let currentScale = scales['classic'];
+
+	export const scale_keys = Object.keys(scales);
 
 	export const initAudio = async () => {
 		destinationStream  = Tone.context.createMediaStreamDestination();
@@ -29,6 +61,10 @@
 		console.log('audio is ready');
 	}
 
+	export const setScale = key => {
+		currentScale = scales[key];
+	}
+
 	export const playRow = async (row) => {
 		if(!synth) {
 			await initAudio();
@@ -37,7 +73,7 @@
 		let notesToPlay = []
 		for (var i = row.length - 1; i >= 0; i--) {
 			if(row[i]) {
-				notesToPlay.push(notes[i]);
+				notesToPlay.push(currentScale[i]);
 			}
 		}
 		synth.triggerAttackRelease(notesToPlay, '16n');
@@ -47,7 +83,7 @@
 		if(!synth) {
 			await initAudio();
 		}
-		synth.triggerAttackRelease(notes[index], '16n');
+		synth.triggerAttackRelease(currentScale[index], '16n');
 	}
 
 	export const stopRecording = async () => {


### PR DESCRIPTION
In reference to https://github.com/irshadshalu/music-grid/issues/12, adds a handful of scale options in a select dropdown (also tried a range -- nothing better came to mind) to choose from and widens the grid by 2 columns to support a full chromatic scale. Encodes the scale in a new hash param, also reads one if present, and assumes classic if none found.

Existing compositions should be unaffected, but visiting them will yield a URL with the scale included.

<img src="https://user-images.githubusercontent.com/435879/85955342-e3937900-b94b-11ea-8e59-4b31b4e02a9d.gif" width=300>

Also, I *think* this will merge cleanly with the play_row_on_tap, but haven't had a chance to try the one atop the other yet.

